### PR TITLE
Sync polar grid with scan and log synchronized data

### DIFF
--- a/src/global_to_polar_cpp/CMakeLists.txt
+++ b/src/global_to_polar_cpp/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(std_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2 REQUIRED)
+find_package(message_filters REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 # ===================================================================
@@ -43,6 +44,7 @@ ament_target_dependencies(data_logger_node
   rclcpp
   std_msgs
   sensor_msgs
+  message_filters
 )
 
 # 사용자 정의 메시지 타입 링크

--- a/src/global_to_polar_cpp/package.xml
+++ b/src/global_to_polar_cpp/package.xml
@@ -16,6 +16,7 @@
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
+  <depend>message_filters</depend>
 
   <!-- custom 메시지 빌드 의존성 -->
   <build_depend>rosidl_default_generators</build_depend>

--- a/src/global_to_polar_cpp/src/dataLoggerNode.cpp
+++ b/src/global_to_polar_cpp/src/dataLoggerNode.cpp
@@ -4,41 +4,39 @@
 #include <fstream>
 #include <vector>
 #include <string>
-#include <iomanip> // For std::setprecision
+#include <iomanip>
+#include <limits>
+#include <cmath>
 
-// Custom message
+#include <message_filters/subscriber.h>
+#include <message_filters/synchronizer.h>
+#include <message_filters/sync_policies/approximate_time.h>
+
 #include "global_to_polar_cpp/msg/polar_grid.hpp"
 
 class DataLoggerNode : public rclcpp::Node
 {
 public:
-    DataLoggerNode() : Node("data_logger_node"), scan_received_(false), grid_received_(false)
+    DataLoggerNode() : Node("data_logger_node"), header_written_(false)
     {
-        // Declare and get parameter for the output CSV file path
-        this->declare_parameter<std::string>("output_csv_file", "datalog.csv");
-        std::string output_csv_file = this->get_parameter("output_csv_file").as_string();
+        output_csv_file_ = this->declare_parameter<std::string>("output_csv_file", "datalog.csv");
+        write_masks_ = this->declare_parameter<bool>("write_masks", false);
+        normalize_ = this->declare_parameter<bool>("normalize", false);
 
-        // Open the CSV file for writing
-        csv_file_.open(output_csv_file, std::ios::out | std::ios::trunc);
+        csv_file_.open(output_csv_file_, std::ios::out | std::ios::trunc);
         if (!csv_file_.is_open()) {
-            RCLCPP_ERROR(this->get_logger(), "Failed to open output file: %s", output_csv_file.c_str());
+            RCLCPP_ERROR(this->get_logger(), "Failed to open output file: %s", output_csv_file_.c_str());
             rclcpp::shutdown();
             return;
         }
 
-        // Write the header row to the CSV file
-        writeHeader();
+        laser_scan_sub_.subscribe(this, "/scan");
+        polar_grid_sub_.subscribe(this, "/polar_grid");
 
-        // Subscribers
-        laser_scan_sub_ = this->create_subscription<sensor_msgs::msg::LaserScan>(
-            "/scan", 10,
-            std::bind(&DataLoggerNode::laserScanCallback, this, std::placeholders::_1));
+        sync_ = std::make_shared<Synchronizer>(SyncPolicy(10), laser_scan_sub_, polar_grid_sub_);
+        sync_->registerCallback(std::bind(&DataLoggerNode::syncCallback, this, std::placeholders::_1, std::placeholders::_2));
 
-        polar_grid_sub_ = this->create_subscription<global_to_polar_cpp::msg::PolarGrid>(
-            "/polar_grid", 10,
-            std::bind(&DataLoggerNode::polarGridCallback, this, std::placeholders::_1));
-
-        RCLCPP_INFO(this->get_logger(), "Data Logger Node initialized. Logging to %s", output_csv_file.c_str());
+        RCLCPP_INFO(this->get_logger(), "Data Logger Node initialized. Logging to %s", output_csv_file_.c_str());
     }
 
     ~DataLoggerNode()
@@ -49,84 +47,143 @@ public:
     }
 
 private:
-    void writeHeader()
+    using LaserScan = sensor_msgs::msg::LaserScan;
+    using PolarGrid = global_to_polar_cpp::msg::PolarGrid;
+    using SyncPolicy = message_filters::sync_policies::ApproximateTime<LaserScan, PolarGrid>;
+    using Synchronizer = message_filters::Synchronizer<SyncPolicy>;
+
+    void writeHeader(size_t n)
     {
-        // LaserScan headers (assuming 1081 points)
-        for (int i = 0; i < 1081; ++i) {
-            csv_file_ << "scan_" << i << ",";
+        csv_file_ << "stamp";
+        for (size_t i = 0; i < n; ++i) {
+            csv_file_ << ",scan_" << i;
         }
-        // PolarGrid headers (1081 points)
-        for (int i = 0; i < 1081; ++i) {
-            csv_file_ << "grid_" << i << (i == 1080 ? "" : ",");
+        for (size_t i = 0; i < n; ++i) {
+            csv_file_ << ",grid_" << i;
+        }
+        if (write_masks_) {
+            for (size_t i = 0; i < n; ++i) {
+                csv_file_ << ",scan_mask_" << i;
+            }
+            for (size_t i = 0; i < n; ++i) {
+                csv_file_ << ",grid_mask_" << i;
+            }
         }
         csv_file_ << "\n";
+        csv_file_.flush();
     }
 
-    void laserScanCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg)
+    double sanitize(double value, double range_min, double range_max, int &mask) const
     {
-        // We assume the laser scan also has 1081 points.
-        // If not, you might need to adjust the logic or header.
-        if (msg->ranges.size() != 1081) {
-             RCLCPP_WARN_ONCE(this->get_logger(), "Received LaserScan with %zu points, expected 1081. CSV columns might not align.", msg->ranges.size());
+        if (!std::isfinite(value) || value < range_min || value > range_max) {
+            mask = 0;
+            return 0.0;
         }
-        last_scan_ = msg;
-        scan_received_ = true;
-        writeData(); // Attempt to write data every time a new scan arrives
+        mask = 1;
+        return normalize_ ? value / range_max : value;
     }
 
-    void polarGridCallback(const global_to_polar_cpp::msg::PolarGrid::SharedPtr msg)
+    void syncCallback(const LaserScan::ConstSharedPtr &scan,
+                      const PolarGrid::ConstSharedPtr &grid)
     {
-        if (msg->ranges.size() != 1081) {
-            RCLCPP_WARN_ONCE(this->get_logger(), "Received PolarGrid with %zu points, expected 1081. CSV columns might not align.", msg->ranges.size());
-        }
-        last_grid_ = msg;
-        grid_received_ = true;
-    }
-
-    void writeData()
-    {
-        // Only write to file if we have received at least one of each message type
-        if (!scan_received_ || !grid_received_) {
+        if (scan->ranges.size() != grid->ranges.size()) {
+            RCLCPP_WARN(this->get_logger(),
+                        "Range size mismatch: scan %zu vs grid %zu. Sample skipped.",
+                        scan->ranges.size(), grid->ranges.size());
             return;
         }
 
-        // Set precision for floating point numbers
-        csv_file_ << std::fixed << std::setprecision(5);
-
-        // Write LaserScan ranges
-        for (size_t i = 0; i < last_scan_->ranges.size(); ++i) {
-            csv_file_ << last_scan_->ranges[i] << ",";
+        if (!header_written_) {
+            range_count_ = scan->ranges.size();
+            angle_min_ = scan->angle_min;
+            angle_max_ = scan->angle_max;
+            angle_increment_ = scan->angle_increment;
+            writeHeader(range_count_);
+            header_written_ = true;
+        } else {
+            if (std::fabs(scan->angle_min - angle_min_) > 1e-6 ||
+                std::fabs(scan->angle_max - angle_max_) > 1e-6 ||
+                std::fabs(scan->angle_increment - angle_increment_) > 1e-9 ||
+                scan->ranges.size() != range_count_) {
+                RCLCPP_WARN(this->get_logger(),
+                            "LaserScan angle metadata changed. Sample skipped.");
+                return;
+            }
         }
 
-        // Write PolarGrid ranges
-        for (size_t i = 0; i < last_grid_->ranges.size(); ++i) {
-            csv_file_ << last_grid_->ranges[i] << (i == last_grid_->ranges.size() - 1 ? "" : ",");
-        }
-        csv_file_ << "\n";
+        try {
+            double stamp = static_cast<double>(scan->header.stamp.sec) +
+                           static_cast<double>(scan->header.stamp.nanosec) * 1e-9;
 
-        // Reset flags to ensure we wait for a new pair of messages
-        scan_received_ = false;
-        grid_received_ = false;
+            csv_file_ << std::fixed << std::setprecision(5);
+            csv_file_ << stamp;
+
+            std::vector<int> scan_mask(range_count_, 0);
+            std::vector<int> grid_mask(range_count_, 0);
+
+            for (size_t i = 0; i < range_count_; ++i) {
+                double val = sanitize(scan->ranges[i], scan->range_min, scan->range_max, scan_mask[i]);
+                csv_file_ << "," << val;
+            }
+
+            for (size_t i = 0; i < range_count_; ++i) {
+                double g = grid->ranges[i];
+                if (!std::isfinite(g) || g <= 0.0) {
+                    grid_mask[i] = 0;
+                    g = 0.0;
+                } else {
+                    grid_mask[i] = 1;
+                    if (normalize_) {
+                        g /= scan->range_max;
+                    }
+                    if (normalize_) {
+                        if (g > 1.0) g = 1.0;
+                    } else {
+                        if (g > scan->range_max) g = scan->range_max;
+                    }
+                }
+                csv_file_ << "," << g;
+            }
+
+            if (write_masks_) {
+                for (size_t i = 0; i < range_count_; ++i) {
+                    csv_file_ << "," << scan_mask[i];
+                }
+                for (size_t i = 0; i < range_count_; ++i) {
+                    csv_file_ << "," << grid_mask[i];
+                }
+            }
+
+            csv_file_ << "\n";
+            csv_file_.flush();
+            if (!csv_file_.good()) {
+                RCLCPP_ERROR(this->get_logger(), "Failed writing to CSV file.");
+            }
+        } catch (const std::exception &e) {
+            RCLCPP_ERROR(this->get_logger(), "Exception while writing CSV: %s", e.what());
+        }
     }
 
-    // Subscribers
-    rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr laser_scan_sub_;
-    rclcpp::Subscription<global_to_polar_cpp::msg::PolarGrid>::SharedPtr polar_grid_sub_;
+    message_filters::Subscriber<LaserScan> laser_scan_sub_;
+    message_filters::Subscriber<PolarGrid> polar_grid_sub_;
+    std::shared_ptr<Synchronizer> sync_;
 
-    // Data storage
-    sensor_msgs::msg::LaserScan::SharedPtr last_scan_;
-    global_to_polar_cpp::msg::PolarGrid::SharedPtr last_grid_;
-    bool scan_received_;
-    bool grid_received_;
-
-    // File handling
     std::ofstream csv_file_;
+    std::string output_csv_file_;
+    bool header_written_;
+    bool write_masks_;
+    bool normalize_;
+    size_t range_count_ {0};
+    double angle_min_ {0.0};
+    double angle_max_ {0.0};
+    double angle_increment_ {0.0};
 };
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
     rclcpp::init(argc, argv);
     rclcpp::spin(std::make_shared<DataLoggerNode>());
     rclcpp::shutdown();
     return 0;
 }
+


### PR DESCRIPTION
## Summary
- Align `GlobalToPolarNode` with LaserScan parameters via configurable angles and range count
- Rewrite `DataLoggerNode` to synchronize /scan and /polar_grid, log timestamped data with optional masks and normalization
- Add message_filters dependency and update build configuration

## Testing
- `colcon build --packages-select global_to_polar_cpp` *(fails: command not found)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a04f239cb48320b55e65819459e302