### PR TITLE
Fix dynamic LaserScan size handling

### DIFF
--- a/src/global_to_polar_cpp/msg/PolarGrid.msg
+++ b/src/global_to_polar_cpp/msg/PolarGrid.msg
@@ -5,5 +5,5 @@
 std_msgs/Header header
 
 # 거리(range) 값들을 담는 배열.
-# global_to_polar_node는 여기에 1081개의 float 값을 채웁니다.
+# LaserScan의 ranges 길이와 동일한 개수의 값을 포함합니다.
 float32[] ranges

--- a/src/global_to_polar_cpp/src/dataLoggerNode.cpp
+++ b/src/global_to_polar_cpp/src/dataLoggerNode.cpp
@@ -101,11 +101,6 @@ private:
             return;
         }
 
-        if (scan->ranges.size() != 1080) {
-            RCLCPP_WARN(this->get_logger(), "LaserScan size %zu != 1080. Sample skipped.", scan->ranges.size());
-            return;
-        }
-
         if (scan->ranges.size() != grid->ranges.size()) {
             RCLCPP_WARN(this->get_logger(),
                         "Range size mismatch: scan %zu vs grid %zu. Sample skipped.",


### PR DESCRIPTION
## Summary
- Log LaserScan data of any size instead of assuming 1080 beams
- Clarify PolarGrid message to describe dynamic range count

## Testing
- `colcon build --packages-select global_to_polar_cpp` *(fails: Could not find package configuration file provided by "ament_cmake")*

------
https://chatgpt.com/codex/tasks/task_e_68a1aa5a28408320b839626f73e1e0c1