### PR TITLE
Align polar grid size and path handling

### DIFF
--- a/src/global_to_polar_cpp/CMakeLists.txt
+++ b/src/global_to_polar_cpp/CMakeLists.txt
@@ -13,7 +13,8 @@ find_package(nav_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
-find_package(planning_custom_msgs REQUIRED)
+find_package(f1tenth_planning_custom_msgs REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 
 # ===================================================================
 # 1. 사용자 정의 메시지 파일
@@ -37,6 +38,7 @@ ament_target_dependencies(global_to_polar_node
   std_msgs
   nav_msgs
   tf2
+  ament_index_cpp
 )
 
 # data_logger_node 실행 파일
@@ -45,7 +47,8 @@ ament_target_dependencies(data_logger_node
   rclcpp
   std_msgs
   sensor_msgs
-  planning_custom_msgs
+  f1tenth_planning_custom_msgs
+  ament_index_cpp
 )
 
 # 사용자 정의 메시지 타입 링크

--- a/src/global_to_polar_cpp/msg/PolarGrid.msg
+++ b/src/global_to_polar_cpp/msg/PolarGrid.msg
@@ -5,5 +5,5 @@
 std_msgs/Header header
 
 # 거리(range) 값들을 담는 배열.
-# global_to_polar_node는 여기에 1081개의 float 값을 채웁니다.
+# global_to_polar_node는 여기에 1080개의 float 값을 채웁니다.
 float32[] ranges

--- a/src/global_to_polar_cpp/package.xml
+++ b/src/global_to_polar_cpp/package.xml
@@ -17,7 +17,8 @@
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
-  <depend>planning_custom_msgs</depend>
+  <depend>f1tenth_planning_custom_msgs</depend>
+  <depend>ament_index_cpp</depend>
 
   <!-- custom 메시지 빌드 의존성 -->
   <build_depend>rosidl_default_generators</build_depend>

--- a/src/global_to_polar_cpp/src/dataLoggerNode.cpp
+++ b/src/global_to_polar_cpp/src/dataLoggerNode.cpp
@@ -7,8 +7,9 @@
 #include <iomanip> // For std::setprecision
 
 // Custom message
-#include "../global_to_polar_cpp/msg/polar_grid.hpp"
-#include "../f1tenth_planning_custom_msgs/msg/path_with_velocity.hpp"
+#include "global_to_polar_cpp/msg/polar_grid.hpp"
+#include "f1tenth_planning_custom_msgs/msg/path_with_velocity.hpp"
+#include <ament_index_cpp/get_package_share_directory.hpp>
 
 class DataLoggerNode : public rclcpp::Node
 {
@@ -16,7 +17,11 @@ public:
     DataLoggerNode() : Node("data_logger_node"), scan_received_(false), grid_received_(false), path_received_(false)
     {
         // Declare and get parameter for the output CSV file path
-        output_csv_file_ = this->declare_parameter<std::string>("output_csv_file", "/home/subin/learning_code/src/global_to_polar_cpp/dataSet/datalog.csv");
+        const std::string default_csv_path =
+            ament_index_cpp::get_package_share_directory("global_to_polar_cpp") +
+            "/dataSet/datalog.csv";
+        output_csv_file_ =
+            this->declare_parameter<std::string>("output_csv_file", default_csv_path);
 
         // Open the CSV file for writing
         csv_file_.open(output_csv_file_, std::ios::out | std::ios::trunc);
@@ -38,9 +43,11 @@ public:
             "/polar_grid", 10,
             std::bind(&DataLoggerNode::polarGridCallback, this, std::placeholders::_1));
 
-        path_point_array_sub_ = this->create_subscription<f1tenth_planning_custom_msgs::msg::PathWithVelocity>(
-            "/planned_path_with_velocity", 10,
-            std::bind(&DataLoggerNode::pathPointArrayCallback, this, std::placeholders::_1));
+        path_with_velocity_sub_ =
+            this->create_subscription<f1tenth_planning_custom_msgs::msg::PathWithVelocity>(
+                "/planned_path_with_velocity", 10,
+                std::bind(&DataLoggerNode::pathWithVelocityCallback, this,
+                          std::placeholders::_1));
 
         RCLCPP_INFO(this->get_logger(), "Data Logger Node initialized. Logging to %s", output_csv_file_.c_str());
     }
@@ -63,7 +70,7 @@ private:
         for (int i = 0; i < 1080; ++i) {
             csv_file_ << "grid_" << i << ",";
         }
-        // PathPointArray headers (16 points with x, y, v, yaw)
+        // PathWithVelocity headers (16 points with x, y, v, yaw)
         for (int i = 0; i < 16; ++i) {
             csv_file_ << "x" << (i+1) << ",";
             csv_file_ << "y" << (i+1) << ",";
@@ -75,10 +82,12 @@ private:
 
     void laserScanCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg)
     {
-        // We assume the laser scan also has 1081 points.
+        // We assume the laser scan has 1080 points.
         // If not, you might need to adjust the logic or header.
         if (msg->ranges.size() != 1080) {
-             RCLCPP_WARN_ONCE(this->get_logger(), "Received LaserScan with %zu points, expected 1081. CSV columns might not align.", msg->ranges.size());
+             RCLCPP_WARN_ONCE(this->get_logger(),
+                              "Received LaserScan with %zu points, expected 1080. CSV columns might not align.",
+                              msg->ranges.size());
         }
         last_scan_ = msg;
         scan_received_ = true;
@@ -88,17 +97,19 @@ private:
     void polarGridCallback(const global_to_polar_cpp::msg::PolarGrid::SharedPtr msg)
     {
         if (msg->ranges.size() != 1080) {
-            RCLCPP_WARN_ONCE(this->get_logger(), "Received PolarGrid with %zu points, expected 1081. CSV columns might not align.", msg->ranges.size());
+            RCLCPP_WARN_ONCE(this->get_logger(),
+                             "Received PolarGrid with %zu points, expected 1080. CSV columns might not align.",
+                             msg->ranges.size());
         }
         last_grid_ = msg;
         grid_received_ = true;
     }
 
-    void pathPointArrayCallback(const planning_custom_msgs::msg::PathPointArray::SharedPtr msg)
+    void pathWithVelocityCallback(const f1tenth_planning_custom_msgs::msg::PathWithVelocity::SharedPtr msg)
     {
         last_path_ = msg;
         path_received_ = true;
-        RCLCPP_INFO(this->get_logger(), "Received PathPointArray with %zu points", msg->points.size());
+        RCLCPP_INFO(this->get_logger(), "Received PathWithVelocity with %zu points", msg->points.size());
     }
 
     void writeData()
@@ -121,7 +132,7 @@ private:
             csv_file_ << last_grid_->ranges[i] << ",";
         }
 
-        // Write PathPointArray data (16 points with x, y, v, yaw)
+        // Write PathWithVelocity data (16 points with x, y, v, yaw)
         for (int i = 0; i < 16; ++i) {
             if (i < static_cast<int>(last_path_->points.size())) {
                 const auto& point = last_path_->points[i];
@@ -148,12 +159,12 @@ private:
     // Subscribers
     rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr laser_scan_sub_;
     rclcpp::Subscription<global_to_polar_cpp::msg::PolarGrid>::SharedPtr polar_grid_sub_;
-    rclcpp::Subscription<planning_custom_msgs::msg::PathPointArray>::SharedPtr path_point_array_sub_;
+    rclcpp::Subscription<f1tenth_planning_custom_msgs::msg::PathWithVelocity>::SharedPtr path_with_velocity_sub_;
 
     // Data storage
     sensor_msgs::msg::LaserScan::SharedPtr last_scan_;
     global_to_polar_cpp::msg::PolarGrid::SharedPtr last_grid_;
-    planning_custom_msgs::msg::PathPointArray::SharedPtr last_path_;
+    f1tenth_planning_custom_msgs::msg::PathWithVelocity::SharedPtr last_path_;
     bool scan_received_;
     bool grid_received_;
     bool path_received_;

--- a/src/global_to_polar_cpp/src/globToPolar.cpp
+++ b/src/global_to_polar_cpp/src/globToPolar.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <limits>
 #include <algorithm>
+#include <ament_index_cpp/get_package_share_directory.hpp>
 
 // 사용자 정의 메시지
 #include "global_to_polar_cpp/msg/polar_grid.hpp"
@@ -24,7 +25,11 @@ public:
     GlobalToPolarNode() : Node("global_to_polar_node")
     {
         // 파라미터 선언 및 값 가져오기
-        std::string path_csv_file = this->declare_parameter<std::string>("path_csv_file", "/home/subin/learning_code/src/global_to_polar_cpp/line/slam_tool_box.csv");
+        const std::string default_path_csv =
+            ament_index_cpp::get_package_share_directory("global_to_polar_cpp") +
+            "/line/slam_tool_box.csv";
+        std::string path_csv_file =
+            this->declare_parameter<std::string>("path_csv_file", default_path_csv);
         lookahead_points_ = this->declare_parameter<int>("lookahead_points", 20);
         search_window_ = this->declare_parameter<int>("search_window", 10);
 
@@ -184,10 +189,10 @@ private:
 
             // 경로점이 우리가 원하는 각도 범위 내에 있는지 확인
             if (relative_angle >= min_angle_rad && relative_angle <= max_angle_rad) {
-                // 1081개 배열에서 해당 각도에 맞는 인덱스 계산
+                // 1080개 배열에서 해당 각도에 맞는 인덱스 계산
                 int index = static_cast<int>(std::round((relative_angle - min_angle_rad) / angle_increment));
 
-                if (index >= 0 && index < 1081) {
+                if (index >= 0 && index < 1080) {
                     // 해당 인덱스가 비어있거나, 새로 계산된 점이 더 가까우면 거리 값을 업데이트
                     if (polar_grid_msg.ranges[index] == 0.0f || distance < polar_grid_msg.ranges[index]) {
                         polar_grid_msg.ranges[index] = static_cast<float>(distance);


### PR DESCRIPTION
## Summary
- Unify polar grid and logging utilities to 1080 elements
- Switch path logging to PathWithVelocity messages
- Replace hard-coded file paths with package-relative paths

## Testing
- `colcon build --packages-select global_to_polar_cpp` *(fails: Could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68a291572c988320af72b09a8dccf7e5