### PR TITLE
Align polar grid size and path handling

### DIFF
--- a/src/global_to_polar_cpp/CMakeLists.txt
+++ b/src/global_to_polar_cpp/CMakeLists.txt
@@ -13,7 +13,14 @@ find_package(nav_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
-find_package(planning_custom_msgs REQUIRED)
+find_package(planning_custom_msgs QUIET)
+if(NOT planning_custom_msgs_FOUND)
+  find_package(f1tenth_planning_custom_msgs REQUIRED)
+  set(path_msgs_pkg f1tenth_planning_custom_msgs)
+else()
+  set(path_msgs_pkg planning_custom_msgs)
+endif()
+find_package(ament_index_cpp REQUIRED)
 
 # ===================================================================
 # 1. 사용자 정의 메시지 파일
@@ -37,6 +44,7 @@ ament_target_dependencies(global_to_polar_node
   std_msgs
   nav_msgs
   tf2
+  ament_index_cpp
 )
 
 # data_logger_node 실행 파일
@@ -45,7 +53,8 @@ ament_target_dependencies(data_logger_node
   rclcpp
   std_msgs
   sensor_msgs
-  planning_custom_msgs
+  ${path_msgs_pkg}
+  ament_index_cpp
 )
 
 # 사용자 정의 메시지 타입 링크
@@ -63,4 +72,5 @@ install(TARGETS
 
 
 ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(${path_msgs_pkg})
 ament_package()

--- a/src/global_to_polar_cpp/msg/PolarGrid.msg
+++ b/src/global_to_polar_cpp/msg/PolarGrid.msg
@@ -5,5 +5,5 @@
 std_msgs/Header header
 
 # 거리(range) 값들을 담는 배열.
-# global_to_polar_node는 여기에 1081개의 float 값을 채웁니다.
+# global_to_polar_node는 여기에 1080개의 float 값을 채웁니다.
 float32[] ranges

--- a/src/global_to_polar_cpp/package.xml
+++ b/src/global_to_polar_cpp/package.xml
@@ -18,6 +18,7 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>planning_custom_msgs</depend>
+  <depend>ament_index_cpp</depend>
 
   <!-- custom 메시지 빌드 의존성 -->
   <build_depend>rosidl_default_generators</build_depend>

--- a/src/global_to_polar_cpp/src/globToPolar.cpp
+++ b/src/global_to_polar_cpp/src/globToPolar.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <limits>
 #include <algorithm>
+#include <ament_index_cpp/get_package_share_directory.hpp>
 
 // 사용자 정의 메시지
 #include "global_to_polar_cpp/msg/polar_grid.hpp"
@@ -24,7 +25,11 @@ public:
     GlobalToPolarNode() : Node("global_to_polar_node")
     {
         // 파라미터 선언 및 값 가져오기
-        std::string path_csv_file = this->declare_parameter<std::string>("path_csv_file", "/home/subin/learning_code/src/global_to_polar_cpp/line/slam_tool_box.csv");
+        const std::string default_path_csv =
+            ament_index_cpp::get_package_share_directory("global_to_polar_cpp") +
+            "/line/slam_tool_box.csv";
+        std::string path_csv_file =
+            this->declare_parameter<std::string>("path_csv_file", default_path_csv);
         lookahead_points_ = this->declare_parameter<int>("lookahead_points", 20);
         search_window_ = this->declare_parameter<int>("search_window", 10);
 
@@ -184,10 +189,10 @@ private:
 
             // 경로점이 우리가 원하는 각도 범위 내에 있는지 확인
             if (relative_angle >= min_angle_rad && relative_angle <= max_angle_rad) {
-                // 1081개 배열에서 해당 각도에 맞는 인덱스 계산
+                // 1080개 배열에서 해당 각도에 맞는 인덱스 계산
                 int index = static_cast<int>(std::round((relative_angle - min_angle_rad) / angle_increment));
 
-                if (index >= 0 && index < 1081) {
+                if (index >= 0 && index < 1080) {
                     // 해당 인덱스가 비어있거나, 새로 계산된 점이 더 가까우면 거리 값을 업데이트
                     if (polar_grid_msg.ranges[index] == 0.0f || distance < polar_grid_msg.ranges[index]) {
                         polar_grid_msg.ranges[index] = static_cast<float>(distance);


### PR DESCRIPTION
## Summary
- Unify polar grid and logging utilities to 1080 elements
- Switch path logging to `PathWithVelocity` messages via `planning_custom_msgs`
- Replace hard-coded file paths with package-relative paths
- Allow build to fallback to legacy `f1tenth_planning_custom_msgs` when the new package isn't available

## Testing
- `apt-get install -y python3-colcon-common-extensions` *(fails: Unable to locate package python3-colcon-common-extensions)*
- `colcon build --packages-select global_to_polar_cpp` *(fails: command not found: colcon)*

------
https://chatgpt.com/codex/tasks/task_e_68a291572c988320af72b09a8dccf7e5