### PR TITLE
Use f1tenth planning PathWithVelocity

### DIFF
--- a/src/global_to_polar_cpp/CMakeLists.txt
+++ b/src/global_to_polar_cpp/CMakeLists.txt
@@ -13,7 +13,6 @@ find_package(nav_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
-find_package(planning_custom_msgs REQUIRED)
 find_package(f1tenth_planning_custom_msgs REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 
@@ -48,7 +47,6 @@ ament_target_dependencies(data_logger_node
   rclcpp
   std_msgs
   sensor_msgs
-  planning_custom_msgs
   f1tenth_planning_custom_msgs
   ament_index_cpp
 )

--- a/src/global_to_polar_cpp/src/dataLoggerNode.cpp
+++ b/src/global_to_polar_cpp/src/dataLoggerNode.cpp
@@ -8,7 +8,6 @@
 
 // Custom message
 #include "global_to_polar_cpp/msg/polar_grid.hpp"
-#include "planning_custom_msgs/msg/path_with_velocity.hpp"
 #include "f1tenth_planning_custom_msgs/msg/path_with_velocity.hpp"
 #include <ament_index_cpp/get_package_share_directory.hpp>
 
@@ -45,7 +44,6 @@ public:
             std::bind(&DataLoggerNode::polarGridCallback, this, std::placeholders::_1));
 
         path_with_velocity_sub_ =
-            this->create_subscription<planning_custom_msgs::msg::PathWithVelocity>(
             this->create_subscription<f1tenth_planning_custom_msgs::msg::PathWithVelocity>(
                 "/planned_path_with_velocity", 10,
                 std::bind(&DataLoggerNode::pathWithVelocityCallback, this,
@@ -107,10 +105,7 @@ private:
         grid_received_ = true;
     }
 
-
-    void pathWithVelocityCallback(const planning_custom_msgs::msg::PathWithVelocity::SharedPtr msg)
     void pathWithVelocityCallback(const f1tenth_planning_custom_msgs::msg::PathWithVelocity::SharedPtr msg)
-
     {
         last_path_ = msg;
         path_received_ = true;
@@ -163,16 +158,13 @@ private:
 
     // Subscribers
     rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr laser_scan_sub_;
-    rclcpp::Subscription<global_to_polar_cpp::msg::PolarGrid>::SharedPtr polar_grid_sub_;  
-    rclcpp::Subscription<planning_custom_msgs::msg::PathWithVelocity>::SharedPtr path_with_velocity_sub_;
+    rclcpp::Subscription<global_to_polar_cpp::msg::PolarGrid>::SharedPtr polar_grid_sub_;
     rclcpp::Subscription<f1tenth_planning_custom_msgs::msg::PathWithVelocity>::SharedPtr path_with_velocity_sub_;
 
 
     // Data storage
     sensor_msgs::msg::LaserScan::SharedPtr last_scan_;
     global_to_polar_cpp::msg::PolarGrid::SharedPtr last_grid_;
-
-    planning_custom_msgs::msg::PathWithVelocity::SharedPtr last_path_;
 
     f1tenth_planning_custom_msgs::msg::PathWithVelocity::SharedPtr last_path_;
 


### PR DESCRIPTION
## Summary
- Switch data logger to `f1tenth_planning_custom_msgs::msg::PathWithVelocity`.
- Drop `planning_custom_msgs` dependency.

## Testing
- `colcon build` *(fails: Could not find package configuration file provided by "ament_cmake")*


------
https://chatgpt.com/codex/tasks/task_e_68a2b386fdd88320bb102c61517656c3