### PR TITLE
Ensure global_to_polar_cpp installs CSV path

### DIFF
--- a/src/global_to_polar_cpp/CMakeLists.txt
+++ b/src/global_to_polar_cpp/CMakeLists.txt
@@ -64,6 +64,13 @@ install(TARGETS
   DESTINATION lib/${PROJECT_NAME}
 )
 
+# Install resource files such as the default CSV map so they are
+# available via ament_index_cpp::get_package_share_directory().
+install(DIRECTORY
+  line
+  DESTINATION share/${PROJECT_NAME}
+)
+
 
 ament_export_dependencies(rosidl_default_runtime)
 ament_package()


### PR DESCRIPTION
## Summary
- install the `line` directory so the default CSV path is available via `ament_index_cpp`

## Testing
- `colcon build --packages-select global_to_polar_cpp` *(failed: Could not find package `ament_cmake`)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b8631b108320bf355049edc15d20