### PR TITLE
Handle missing data log directory in data_logger_node

### DIFF
--- a/src/global_to_polar_cpp/CMakeLists.txt
+++ b/src/global_to_polar_cpp/CMakeLists.txt
@@ -50,6 +50,7 @@ ament_target_dependencies(data_logger_node
   f1tenth_planning_custom_msgs
   ament_index_cpp
 )
+target_compile_features(data_logger_node PRIVATE cxx_std_17)
 
 # 사용자 정의 메시지 타입 링크
 target_link_libraries(global_to_polar_node "${cpp_typesupport_target}")

--- a/src/global_to_polar_cpp/src/dataLoggerNode.cpp
+++ b/src/global_to_polar_cpp/src/dataLoggerNode.cpp
@@ -5,6 +5,8 @@
 #include <vector>
 #include <string>
 #include <iomanip> // For std::setprecision
+#include <filesystem>
+#include <stdexcept>
 
 // Custom message
 #include "global_to_polar_cpp/msg/polar_grid.hpp"
@@ -23,12 +25,21 @@ public:
         output_csv_file_ =
             this->declare_parameter<std::string>("output_csv_file", default_csv_path);
 
+        // Ensure the directory exists before opening the file
+        auto parent_dir = std::filesystem::path(output_csv_file_).parent_path();
+        std::error_code ec;
+        std::filesystem::create_directories(parent_dir, ec);
+        if (ec) {
+            RCLCPP_WARN(this->get_logger(),
+                        "Failed to create directory %s: %s",
+                        parent_dir.c_str(), ec.message().c_str());
+        }
+
         // Open the CSV file for writing
         csv_file_.open(output_csv_file_, std::ios::out | std::ios::trunc);
         if (!csv_file_.is_open()) {
             RCLCPP_ERROR(this->get_logger(), "Failed to open output file: %s", output_csv_file_.c_str());
-            rclcpp::shutdown();
-            return;
+            throw std::runtime_error("Failed to open output file: " + output_csv_file_);
         }
 
         // Write the header row to the CSV file
@@ -180,7 +191,12 @@ private:
 int main(int argc, char** argv)
 {
     rclcpp::init(argc, argv);
-    rclcpp::spin(std::make_shared<DataLoggerNode>());
+    try {
+        rclcpp::spin(std::make_shared<DataLoggerNode>());
+    } catch (const std::exception& e) {
+        RCLCPP_ERROR(rclcpp::get_logger("data_logger_node"),
+                    "Exception caught: %s", e.what());
+    }
     rclcpp::shutdown();
     return 0;
 }


### PR DESCRIPTION
## Summary
- Create the data log directory before opening CSV
- Use exceptions instead of shutting down on file errors
- Compile data_logger_node with C++17 for std::filesystem

## Testing
- `colcon build --packages-select global_to_polar_cpp` *(fails: command not found)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ba8d87088320a75c589e81ff5684