### PR TITLE
Default data logs to package dataset

### DIFF
--- a/src/global_to_polar_cpp/CMakeLists.txt
+++ b/src/global_to_polar_cpp/CMakeLists.txt
@@ -50,6 +50,7 @@ ament_target_dependencies(data_logger_node
   f1tenth_planning_custom_msgs
   ament_index_cpp
 )
+target_compile_features(data_logger_node PRIVATE cxx_std_17)
 
 # 사용자 정의 메시지 타입 링크
 target_link_libraries(global_to_polar_node "${cpp_typesupport_target}")

--- a/src/global_to_polar_cpp/dataSet/.gitignore
+++ b/src/global_to_polar_cpp/dataSet/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- Save data logger output under the package's `dataSet` folder by default using a path derived from the source tree
- Track an empty `dataSet` directory for log output while ignoring generated files

## Testing
- ⚠️ `colcon build --packages-select global_to_polar_cpp` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a2ba8d87088320a75c589e81ff5684